### PR TITLE
WebSocket 자동 재연결 + 지수 백오프 1→60s (#2)

### DIFF
--- a/shared/src/event.rs
+++ b/shared/src/event.rs
@@ -59,6 +59,7 @@ pub enum SystemKind {
     Unsubscribed,
     Revoked,
     Disconnected,
+    Reconnecting,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/ws/chzzk.rs
+++ b/src-tauri/src/ws/chzzk.rs
@@ -10,12 +10,43 @@ use url::Url;
 
 use crate::auth;
 use crate::ws::engineio::{self, EnginePacket, SocketIoPacket};
+use crate::ws::reconnect::{classify_session_error, Backoff, SessionOutcome};
 
 pub async fn run_chzzk(
     auth: ChzzkAuth,
     tx: broadcast::Sender<EventEnvelope>,
 ) -> Result<(), IpcError> {
-    let session_url = auth::fetch_chzzk_session_url(&auth).await?;
+    let mut backoff = Backoff::new();
+    loop {
+        match connect_chzzk_once(&auth, &tx, &mut backoff).await {
+            Ok(SessionOutcome::Disconnected) => {}
+            Ok(SessionOutcome::AuthFailed) => {
+                // TODO(#3): refresh token hook. 현재는 즉시 종료.
+                tracing::warn!("치지직 인증 실패 — refresh hook 미구현 (#3), 재연결 중단");
+                break;
+            }
+            Err(e) => tracing::warn!(?e, "치지직 1회 세션 실패"),
+        }
+
+        let delay = backoff.next_delay();
+        let _ = tx.send(envelope(LiveEvent::System(SystemEvent {
+            kind: SystemKind::Reconnecting,
+            message: format!("치지직 재연결 대기 중 ({}초 후)", delay.as_secs()),
+        })));
+        tokio::time::sleep(delay).await;
+    }
+    Ok(())
+}
+
+async fn connect_chzzk_once(
+    auth: &ChzzkAuth,
+    tx: &broadcast::Sender<EventEnvelope>,
+    backoff: &mut Backoff,
+) -> Result<SessionOutcome, IpcError> {
+    let session_url = match auth::fetch_chzzk_session_url(auth).await {
+        Ok(url) => url,
+        Err(e) => return classify_session_error(e),
+    };
     let ws_url = build_ws_url(&session_url)?;
     tracing::info!(%ws_url, "치지직 WS 연결 시도");
 
@@ -50,7 +81,7 @@ pub async fn run_chzzk(
                 }
             }
             Ok(EnginePacket::Message(SocketIoPacket::Event(payload))) => {
-                if let Err(e) = handle_event(payload, &auth, &tx).await {
+                if let Err(e) = handle_event(payload, auth, tx, backoff).await {
                     tracing::warn!(?e, "치지직 이벤트 처리 실패");
                 }
             }
@@ -64,7 +95,7 @@ pub async fn run_chzzk(
         kind: SystemKind::Disconnected,
         message: "치지직 연결 종료".into(),
     })));
-    Ok(())
+    Ok(SessionOutcome::Disconnected)
 }
 
 fn build_ws_url(raw: &str) -> Result<Url, IpcError> {
@@ -93,6 +124,7 @@ async fn handle_event(
     payload: &str,
     auth: &ChzzkAuth,
     tx: &broadcast::Sender<EventEnvelope>,
+    backoff: &mut Backoff,
 ) -> Result<(), IpcError> {
     let arr: serde_json::Value =
         serde_json::from_str(payload).map_err(|e| IpcError::Protocol(e.to_string()))?;
@@ -106,7 +138,7 @@ async fn handle_event(
     let data = arr.get(1).cloned().unwrap_or(serde_json::Value::Null);
 
     match name {
-        "SYSTEM" => handle_system(&data, auth, tx).await,
+        "SYSTEM" => handle_system(&data, auth, tx, backoff).await,
         "CHAT" => {
             let _ = tx.send(envelope(LiveEvent::Chat(parse_chat(&data))));
             Ok(())
@@ -127,6 +159,7 @@ async fn handle_system(
     data: &serde_json::Value,
     auth: &ChzzkAuth,
     tx: &broadcast::Sender<EventEnvelope>,
+    backoff: &mut Backoff,
 ) -> Result<(), IpcError> {
     let kind = data.get("type").and_then(|x| x.as_str()).unwrap_or("");
     let inner = data.get("data");
@@ -137,6 +170,7 @@ async fn handle_system(
                 .and_then(|x| x.as_str())
                 .unwrap_or_default()
                 .to_string();
+            backoff.reset();
             let _ = tx.send(envelope(LiveEvent::System(SystemEvent {
                 kind: SystemKind::Connected,
                 message: "치지직 연결됨".into(),

--- a/src-tauri/src/ws/cime.rs
+++ b/src-tauri/src/ws/cime.rs
@@ -11,6 +11,7 @@ use tokio_tungstenite::tungstenite::Message;
 use url::Url;
 
 use crate::auth;
+use crate::ws::reconnect::{classify_session_error, Backoff, SessionOutcome};
 
 const PING_INTERVAL_SECS: u64 = 60;
 
@@ -18,7 +19,37 @@ pub async fn run_cime(
     auth: CimeAuth,
     tx: broadcast::Sender<EventEnvelope>,
 ) -> Result<(), IpcError> {
-    let session_url = auth::fetch_cime_session_url(&auth).await?;
+    let mut backoff = Backoff::new();
+    loop {
+        match connect_cime_once(&auth, &tx, &mut backoff).await {
+            Ok(SessionOutcome::Disconnected) => {}
+            Ok(SessionOutcome::AuthFailed) => {
+                // TODO(#3): refresh token hook. 현재는 즉시 종료.
+                tracing::warn!("씨미 인증 실패 — refresh hook 미구현 (#3), 재연결 중단");
+                break;
+            }
+            Err(e) => tracing::warn!(?e, "씨미 1회 세션 실패"),
+        }
+
+        let delay = backoff.next_delay();
+        let _ = tx.send(envelope(LiveEvent::System(SystemEvent {
+            kind: SystemKind::Reconnecting,
+            message: format!("씨미 재연결 대기 중 ({}초 후)", delay.as_secs()),
+        })));
+        tokio::time::sleep(delay).await;
+    }
+    Ok(())
+}
+
+async fn connect_cime_once(
+    auth: &CimeAuth,
+    tx: &broadcast::Sender<EventEnvelope>,
+    backoff: &mut Backoff,
+) -> Result<SessionOutcome, IpcError> {
+    let session_url = match auth::fetch_cime_session_url(auth).await {
+        Ok(url) => url,
+        Err(e) => return classify_session_error(e),
+    };
     let session_key = extract_session_key(&session_url)?;
 
     tracing::info!(%session_key, "씨미 WS 연결 시도");
@@ -28,11 +59,12 @@ pub async fn run_cime(
     let (mut sink, mut stream) = ws.split();
 
     for event in ["chat", "donation", "subscription"] {
-        if let Err(e) = auth::subscribe_cime_event(&auth, &session_key, event).await {
+        if let Err(e) = auth::subscribe_cime_event(auth, &session_key, event).await {
             tracing::warn!(?e, event, "씨미 이벤트 구독 실패");
         }
     }
 
+    backoff.reset();
     let _ = tx.send(envelope(LiveEvent::System(SystemEvent {
         kind: SystemKind::Connected,
         message: "씨미 연결됨".into(),
@@ -52,7 +84,7 @@ pub async fn run_cime(
             msg = stream.next() => {
                 match msg {
                     Some(Ok(Message::Text(t))) => {
-                        if let Err(e) = dispatch(&t, &tx) {
+                        if let Err(e) = dispatch(&t, tx) {
                             tracing::warn!(?e, "씨미 메시지 디스패치 실패");
                         }
                     }
@@ -71,7 +103,7 @@ pub async fn run_cime(
         kind: SystemKind::Disconnected,
         message: "씨미 연결 종료".into(),
     })));
-    Ok(())
+    Ok(SessionOutcome::Disconnected)
 }
 
 fn extract_session_key(raw: &str) -> Result<String, IpcError> {

--- a/src-tauri/src/ws/mod.rs
+++ b/src-tauri/src/ws/mod.rs
@@ -1,3 +1,4 @@
 pub mod chzzk;
 pub mod cime;
 pub mod engineio;
+pub mod reconnect;

--- a/src-tauri/src/ws/reconnect.rs
+++ b/src-tauri/src/ws/reconnect.rs
@@ -1,0 +1,79 @@
+use std::time::Duration;
+
+use shared::IpcError;
+
+pub enum SessionOutcome {
+    Disconnected,
+    AuthFailed,
+}
+
+pub fn classify_session_error(e: IpcError) -> Result<SessionOutcome, IpcError> {
+    match e {
+        IpcError::Auth(_) => Ok(SessionOutcome::AuthFailed),
+        other => Err(other),
+    }
+}
+
+pub struct Backoff {
+    initial: Duration,
+    max: Duration,
+    current: Duration,
+}
+
+impl Backoff {
+    pub fn new() -> Self {
+        Self {
+            initial: Duration::from_secs(1),
+            max: Duration::from_secs(60),
+            current: Duration::from_secs(1),
+        }
+    }
+
+    pub fn next_delay(&mut self) -> Duration {
+        let d = self.current;
+        self.current = (self.current * 2).min(self.max);
+        d
+    }
+
+    pub fn reset(&mut self) {
+        self.current = self.initial;
+    }
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequence_doubles_until_clamp() {
+        let mut b = Backoff::new();
+        let secs: Vec<u64> = (0..8).map(|_| b.next_delay().as_secs()).collect();
+        assert_eq!(secs, vec![1, 2, 4, 8, 16, 32, 60, 60]);
+    }
+
+    #[test]
+    fn reset_returns_to_initial() {
+        let mut b = Backoff::new();
+        for _ in 0..5 {
+            let _ = b.next_delay();
+        }
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+        assert_eq!(b.next_delay(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn clamp_holds_at_max() {
+        let mut b = Backoff::new();
+        for _ in 0..20 {
+            let _ = b.next_delay();
+        }
+        assert_eq!(b.next_delay(), Duration::from_secs(60));
+    }
+}

--- a/src/components/connection_status.rs
+++ b/src/components/connection_status.rs
@@ -35,6 +35,7 @@ pub fn ConnectionStatus(
             Some(SystemKind::Unsubscribed) => format!("{name} 구독 해제"),
             Some(SystemKind::Disconnected) => format!("{name} 연결 끊김"),
             Some(SystemKind::Revoked) => format!("{name} 권한 회수됨"),
+            Some(SystemKind::Reconnecting) => format!("{name} 재연결 중"),
             None => format!("{name} 대기"),
         };
         let mock = if mock_enabled.get() {


### PR DESCRIPTION
## 요약
- `run_cime`/`run_chzzk`를 재연결 루프(pub) + `connect_*_once`(1회 세션)로 분리
- `Backoff` (1→2→4→8→16→32→60s clamp) + `SessionOutcome` + `classify_session_error` 헬퍼를 `ws/reconnect.rs`에 신설, 단위 테스트 3개
- `SystemKind::Reconnecting` 추가 — 백오프 sleep 직전 polite 알림으로 화면리더가 "재연결 대기 중 (N초 후)" announce
- 401(`IpcError::Auth`)은 `SessionOutcome::AuthFailed`로 즉시 종료, refresh hook은 #3에서 도입
- `tokio::time::sleep`/`connect_async` 모두 cancel-safe → 기존 `JoinHandle::abort()` 메커니즘 그대로 사용 (sources.rs/state.rs/lib.rs 무변경)

## 검증
- [x] cargo fmt --check
- [x] cargo check --workspace --all-targets
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace (Backoff 단위 테스트 3개 + 기존 6개 통과)
- [x] leptos-audit 13/13 clean
- [x] a11y-audit — Reconnecting을 polite로만 보낸 결정 적절

## 후속 (별도 이슈/PR)
- 사용자 테스트(#12)에서 백오프 매 시도 emit이 EventLog에 잡음 누적시키는지 평가, 필요 시 collapse
- SystemEvent.message의 플랫폼 prefix 중복(`"씨미 시스템 : 씨미 ..."`) 일관 정리 — 기존 모든 메시지 동일 패턴이라 본 PR scope 밖
- #3 Refresh Token 갱신 hook을 `SessionOutcome::AuthFailed` 자리에 연결

## 수동 검증 (리뷰어/머지 후)
- [ ] cargo tauri dev → 유효 토큰으로 연결 확인
- [ ] Wi-Fi 토글 또는 hosts 매핑으로 ws 끊김 유도 → polite 영역에 "재연결 대기 중 (1초 후)" → "(2초 후)" → "연결됨" 순서 announce
- [ ] 백오프 sleep 도중 `stop_event_source` 호출 → 다음 announcement가 들어오지 않으면 abort cancel-safe 확인

Closes #2