### PR TITLE
보안: 인증 토큰을 OS keyring으로 이주 (#1)

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -10,5 +10,5 @@ pub use event::{
     SystemEvent, SystemKind, UserRole,
 };
 pub use platform::Platform;
-pub use settings::{ChzzkAuth, CimeAuth, Settings};
+pub use settings::{ChzzkAuth, ChzzkSecrets, CimeAuth, CimeSecrets, SecretsPresence, Settings};
 pub use summary::{SummaryRequest, SummaryResponse};

--- a/shared/src/settings.rs
+++ b/shared/src/settings.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+/// 비비밀 설정만 보관. 비밀(client_secret, access_token)은 OS keyring에 저장.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
-    pub chzzk: Option<ChzzkAuth>,
-    pub cime: Option<CimeAuth>,
+    pub chzzk_client_id: Option<String>,
     pub channel_id: String,
     pub summary_interval_secs: u32,
     pub max_braille_cells: u32,
@@ -13,8 +13,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            chzzk: None,
-            cime: None,
+            chzzk_client_id: None,
             channel_id: String::new(),
             summary_interval_secs: 30,
             max_braille_cells: 32,
@@ -23,6 +22,27 @@ impl Default for Settings {
     }
 }
 
+/// keyring에 저장되는 치지직 비밀. 평문으로 store/JSON에 직렬화 금지.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChzzkSecrets {
+    pub client_secret: String,
+    pub access_token: Option<String>,
+}
+
+/// keyring에 저장되는 씨미 비밀.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CimeSecrets {
+    pub access_token: String,
+}
+
+/// 폼 placeholder/aria 안내용. 평문은 절대 노출하지 않고 존재 여부만 전달.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretsPresence {
+    pub chzzk_present: bool,
+    pub cime_present: bool,
+}
+
+/// WS/HTTP 호출에 쓰이는 런타임 합성 타입. Settings + Secrets에서 합성된다.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChzzkAuth {
     pub client_id: String,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
 async-trait = "0.1"
+keyring = "3"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,9 @@
-use shared::{IpcError, Settings};
+use serde_json::Value;
+use shared::{ChzzkSecrets, CimeSecrets, IpcError, SecretsPresence, Settings};
 use tauri::{AppHandle, Wry};
 use tauri_plugin_store::StoreExt;
+
+use crate::secrets;
 
 const STORE_FILE: &str = "settings.json";
 const KEY: &str = "settings";
@@ -13,11 +16,21 @@ fn store(app: &AppHandle) -> Result<std::sync::Arc<tauri_plugin_store::Store<Wry
 #[tauri::command]
 pub async fn get_settings(app: AppHandle) -> Result<Settings, IpcError> {
     let store = store(&app)?;
-    match store.get(KEY) {
-        Some(value) => serde_json::from_value(value)
-            .map_err(|e| IpcError::Internal(format!("설정 파싱 실패: {e}"))),
-        None => Ok(Settings::default()),
+    let raw = match store.get(KEY) {
+        Some(v) => v,
+        None => return Ok(Settings::default()),
+    };
+
+    let migrated = migrate_legacy_secrets(raw).await?;
+    if let Some(new_value) = migrated.write_back {
+        store.set(KEY, new_value);
+        store
+            .save()
+            .map_err(|e| IpcError::Internal(format!("설정 저장 실패: {e}")))?;
     }
+
+    serde_json::from_value(migrated.settings)
+        .map_err(|e| IpcError::Internal(format!("설정 파싱 실패: {e}")))
 }
 
 #[tauri::command]
@@ -31,6 +44,98 @@ pub async fn save_settings(app: AppHandle, settings: Settings) -> Result<(), Ipc
     Ok(())
 }
 
+#[tauri::command]
+pub async fn save_secrets(
+    chzzk: Option<ChzzkSecrets>,
+    cime: Option<CimeSecrets>,
+) -> Result<(), IpcError> {
+    if let Some(s) = chzzk {
+        secrets::save_chzzk_async(s).await?;
+    }
+    if let Some(s) = cime {
+        secrets::save_cime_async(s).await?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_secrets_presence() -> Result<SecretsPresence, IpcError> {
+    let chzzk_present = secrets::load_chzzk_async().await?.is_some();
+    let cime_present = secrets::load_cime_async().await?.is_some();
+    Ok(SecretsPresence {
+        chzzk_present,
+        cime_present,
+    })
+}
+
 pub async fn load_settings(app: &AppHandle) -> Result<Settings, IpcError> {
     get_settings(app.clone()).await
+}
+
+pub async fn load_secrets() -> Result<(Option<ChzzkSecrets>, Option<CimeSecrets>), IpcError> {
+    Ok((
+        secrets::load_chzzk_async().await?,
+        secrets::load_cime_async().await?,
+    ))
+}
+
+struct Migrated {
+    settings: Value,
+    write_back: Option<Value>,
+}
+
+/// 구 형식(`chzzk: {client_id, client_secret, access_token}`, `cime: {access_token}`)에서
+/// 비밀 필드를 keyring으로 옮기고 store에는 비비밀만 남긴다. idempotent.
+async fn migrate_legacy_secrets(raw: Value) -> Result<Migrated, IpcError> {
+    let Value::Object(mut map) = raw else {
+        return Ok(Migrated {
+            settings: Value::Object(serde_json::Map::new()),
+            write_back: None,
+        });
+    };
+    let mut changed = false;
+
+    if let Some(Value::Object(chzzk)) = map.remove("chzzk") {
+        let client_id = chzzk
+            .get("client_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let client_secret = chzzk
+            .get("client_secret")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let access_token = chzzk
+            .get("access_token")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+
+        if let Some(secret) = client_secret {
+            secrets::save_chzzk_async(ChzzkSecrets {
+                client_secret: secret,
+                access_token,
+            })
+            .await?;
+            changed = true;
+        }
+        if let Some(id) = client_id {
+            map.insert("chzzk_client_id".into(), Value::String(id));
+            changed = true;
+        }
+    }
+
+    if let Some(Value::Object(cime)) = map.remove("cime") {
+        if let Some(token) = cime.get("access_token").and_then(Value::as_str) {
+            secrets::save_cime_async(CimeSecrets {
+                access_token: token.to_owned(),
+            })
+            .await?;
+            changed = true;
+        }
+    }
+
+    let settings = Value::Object(map);
+    Ok(Migrated {
+        write_back: changed.then(|| settings.clone()),
+        settings,
+    })
 }

--- a/src-tauri/src/commands/sources.rs
+++ b/src-tauri/src/commands/sources.rs
@@ -1,7 +1,7 @@
-use shared::{IpcError, Platform};
+use shared::{ChzzkAuth, CimeAuth, IpcError, Platform};
 use tauri::{AppHandle, State};
 
-use crate::commands::settings::load_settings;
+use crate::commands::settings::{load_secrets, load_settings};
 use crate::state::{AppState, ConnectionHandle};
 use crate::{mock, ws};
 
@@ -12,14 +12,23 @@ pub async fn start_event_source(
     platform: Platform,
 ) -> Result<(), IpcError> {
     let settings = load_settings(&app).await?;
+    let (chzzk_secrets, cime_secrets) = load_secrets().await?;
     stop_inner(&state, platform);
 
     let tx = state.event_tx.clone();
     let handle = match platform {
         Platform::Chzzk => {
-            let auth = settings
-                .chzzk
-                .ok_or_else(|| IpcError::MissingConfig("치지직 인증".into()))?;
+            let client_id = settings
+                .chzzk_client_id
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| IpcError::MissingConfig("치지직 Client ID".into()))?;
+            let secrets =
+                chzzk_secrets.ok_or_else(|| IpcError::MissingConfig("치지직 인증".into()))?;
+            let auth = ChzzkAuth {
+                client_id,
+                client_secret: secrets.client_secret,
+                access_token: secrets.access_token,
+            };
             tauri::async_runtime::spawn(async move {
                 if let Err(e) = ws::chzzk::run_chzzk(auth, tx).await {
                     tracing::error!(?e, "치지직 세션 종료");
@@ -27,9 +36,11 @@ pub async fn start_event_source(
             })
         }
         Platform::Cime => {
-            let auth = settings
-                .cime
-                .ok_or_else(|| IpcError::MissingConfig("씨미 인증".into()))?;
+            let secrets =
+                cime_secrets.ok_or_else(|| IpcError::MissingConfig("씨미 인증".into()))?;
+            let auth = CimeAuth {
+                access_token: secrets.access_token,
+            };
             tauri::async_runtime::spawn(async move {
                 if let Err(e) = ws::cime::run_cime(auth, tx).await {
                     tracing::error!(?e, "씨미 세션 종료");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod auth;
 mod commands;
 mod llm;
 mod mock;
+mod secrets;
 mod state;
 mod ws;
 
@@ -36,6 +37,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::settings::get_settings,
             commands::settings::save_settings,
+            commands::settings::save_secrets,
+            commands::settings::get_secrets_presence,
             commands::sources::start_event_source,
             commands::sources::stop_event_source,
             commands::sources::start_mock_source,

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,0 +1,93 @@
+use keyring::Entry;
+use shared::{ChzzkSecrets, CimeSecrets, IpcError};
+
+const SERVICE: &str = "jeomjwabot";
+const KEY_CHZZK_CLIENT_SECRET: &str = "chzzk.client_secret";
+const KEY_CHZZK_ACCESS_TOKEN: &str = "chzzk.access_token";
+const KEY_CIME_ACCESS_TOKEN: &str = "cime.access_token";
+
+fn entry(key: &str) -> Result<Entry, IpcError> {
+    Entry::new(SERVICE, key).map_err(map_err)
+}
+
+fn map_err(e: keyring::Error) -> IpcError {
+    IpcError::Internal(format!("keyring: {e}"))
+}
+
+fn read_optional(key: &str) -> Result<Option<String>, IpcError> {
+    match entry(key)?.get_password() {
+        Ok(v) => Ok(Some(v)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+fn write(key: &str, value: &str) -> Result<(), IpcError> {
+    entry(key)?.set_password(value).map_err(map_err)
+}
+
+fn delete_if_present(key: &str) -> Result<(), IpcError> {
+    match entry(key)?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+pub fn save_chzzk(secrets: &ChzzkSecrets) -> Result<(), IpcError> {
+    write(KEY_CHZZK_CLIENT_SECRET, &secrets.client_secret)?;
+    match secrets.access_token.as_deref() {
+        Some(token) => write(KEY_CHZZK_ACCESS_TOKEN, token)?,
+        None => delete_if_present(KEY_CHZZK_ACCESS_TOKEN)?,
+    }
+    Ok(())
+}
+
+pub fn load_chzzk() -> Result<Option<ChzzkSecrets>, IpcError> {
+    let Some(client_secret) = read_optional(KEY_CHZZK_CLIENT_SECRET)? else {
+        return Ok(None);
+    };
+    let access_token = read_optional(KEY_CHZZK_ACCESS_TOKEN)?;
+    Ok(Some(ChzzkSecrets {
+        client_secret,
+        access_token,
+    }))
+}
+
+pub fn save_cime(secrets: &CimeSecrets) -> Result<(), IpcError> {
+    write(KEY_CIME_ACCESS_TOKEN, &secrets.access_token)
+}
+
+pub fn load_cime() -> Result<Option<CimeSecrets>, IpcError> {
+    Ok(read_optional(KEY_CIME_ACCESS_TOKEN)?.map(|access_token| CimeSecrets { access_token }))
+}
+
+async fn join<T>(
+    handle: tauri::async_runtime::JoinHandle<Result<T, IpcError>>,
+) -> Result<T, IpcError> {
+    handle
+        .await
+        .map_err(|e| IpcError::Internal(format!("keyring spawn: {e}")))?
+}
+
+pub async fn save_chzzk_async(secrets: ChzzkSecrets) -> Result<(), IpcError> {
+    join(tauri::async_runtime::spawn_blocking(move || {
+        save_chzzk(&secrets)
+    }))
+    .await
+}
+
+pub async fn load_chzzk_async() -> Result<Option<ChzzkSecrets>, IpcError> {
+    join(tauri::async_runtime::spawn_blocking(load_chzzk)).await
+}
+
+pub async fn save_cime_async(secrets: CimeSecrets) -> Result<(), IpcError> {
+    join(tauri::async_runtime::spawn_blocking(move || {
+        save_cime(&secrets)
+    }))
+    .await
+}
+
+pub async fn load_cime_async() -> Result<Option<CimeSecrets>, IpcError> {
+    join(tauri::async_runtime::spawn_blocking(load_cime)).await
+}

--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -1,13 +1,41 @@
 use leptos::prelude::*;
-use shared::{ChzzkAuth, CimeAuth, IpcError, Platform, Settings};
+use shared::{ChzzkSecrets, CimeSecrets, IpcError, Platform, SecretsPresence, Settings};
 
 use crate::ipc;
 
+#[derive(Default, Clone)]
+struct SecretInputs {
+    chzzk_client_secret: String,
+    cime_access_token: String,
+}
+
+struct SavePayload {
+    settings: Settings,
+    secrets: SecretInputs,
+}
+
 #[component]
 pub fn SettingsForm(settings: RwSignal<Settings>) -> impl IntoView {
-    let save_action = Action::new_local(|payload: &Settings| {
-        let payload = payload.clone();
-        async move { apply_and_save(payload).await }
+    let secret_inputs: RwSignal<SecretInputs> = RwSignal::new(SecretInputs::default());
+    let presence = LocalResource::new(|| async {
+        ipc::get_secrets_presence()
+            .await
+            .unwrap_or(SecretsPresence {
+                chzzk_present: false,
+                cime_present: false,
+            })
+    });
+
+    let save_action = Action::new_local(|payload: &SavePayload| {
+        let settings = payload.settings.clone();
+        let secrets = payload.secrets.clone();
+        async move { apply_and_save(settings, secrets).await }
+    });
+
+    Effect::new(move |_| {
+        if save_action.value().get().is_some() {
+            presence.refetch();
+        }
     });
 
     let save_msg = move || match save_action.value().get() {
@@ -17,12 +45,26 @@ pub fn SettingsForm(settings: RwSignal<Settings>) -> impl IntoView {
         Some(Err(e)) => format!("저장 실패: {e}"),
     };
 
+    let chzzk_secret_hint = move || match presence.get() {
+        None => "저장 상태 확인 중.",
+        Some(p) if p.chzzk_present => "저장됨. 변경하려면 새 값 입력.",
+        Some(_) => "아직 저장되지 않음.",
+    };
+    let cime_token_hint = move || match presence.get() {
+        None => "저장 상태 확인 중.",
+        Some(p) if p.cime_present => "저장됨. 변경하려면 새 값 입력.",
+        Some(_) => "아직 저장되지 않음.",
+    };
+
     view! {
         <section aria-labelledby="settings-heading">
             <h2 id="settings-heading">"설정"</h2>
             <form on:submit=move |ev| {
                 ev.prevent_default();
-                save_action.dispatch(settings.get_untracked());
+                save_action.dispatch(SavePayload {
+                    settings: settings.get_untracked(),
+                    secrets: secret_inputs.get_untracked(),
+                });
             }>
                 <div>
                     <label for="channel-id">"채널 ID"</label>
@@ -42,7 +84,7 @@ pub fn SettingsForm(settings: RwSignal<Settings>) -> impl IntoView {
                             }
                         } />
                     <span id="interval-help" class="hint">
-                        "10초에서 600초 사이. 너무 짧으면 점자 단말기가 따라잡지 못합니다."
+                        "10초~600초. 너무 짧으면 점자 출력이 밀립니다."
                     </span>
                 </div>
 
@@ -75,20 +117,22 @@ pub fn SettingsForm(settings: RwSignal<Settings>) -> impl IntoView {
                     <div>
                         <label for="chzzk-cid">"Client ID"</label>
                         <input id="chzzk-cid" type="text" autocomplete="off"
-                            prop:value=move || settings.with(|s| s.chzzk.as_ref().map(|c| c.client_id.clone()).unwrap_or_default())
+                            prop:value=move || settings.with(|s| s.chzzk_client_id.clone().unwrap_or_default())
                             on:input=move |ev| {
                                 let v = event_target_value(&ev);
-                                settings.update(|s| set_chzzk_field(s, |c| c.client_id = v));
+                                settings.update(|s| s.chzzk_client_id = (!v.is_empty()).then_some(v));
                             } />
                     </div>
                     <div>
                         <label for="chzzk-secret">"Client Secret"</label>
                         <input id="chzzk-secret" type="password" autocomplete="off"
-                            prop:value=move || settings.with(|s| s.chzzk.as_ref().map(|c| c.client_secret.clone()).unwrap_or_default())
+                            aria-describedby="chzzk-secret-hint"
+                            prop:value=move || secret_inputs.with(|s| s.chzzk_client_secret.clone())
                             on:input=move |ev| {
                                 let v = event_target_value(&ev);
-                                settings.update(|s| set_chzzk_field(s, |c| c.client_secret = v));
+                                secret_inputs.update(|s| s.chzzk_client_secret = v);
                             } />
+                        <span id="chzzk-secret-hint" class="hint">{move || chzzk_secret_hint()}</span>
                     </div>
                 </fieldset>
 
@@ -97,56 +141,63 @@ pub fn SettingsForm(settings: RwSignal<Settings>) -> impl IntoView {
                     <div>
                         <label for="cime-token">"Access Token"</label>
                         <input id="cime-token" type="password" autocomplete="off"
-                            prop:value=move || settings.with(|s| s.cime.as_ref().map(|c| c.access_token.clone()).unwrap_or_default())
+                            aria-describedby="cime-token-hint"
+                            prop:value=move || secret_inputs.with(|s| s.cime_access_token.clone())
                             on:input=move |ev| {
                                 let v = event_target_value(&ev);
-                                settings.update(|s| {
-                                    s.cime = if v.is_empty() {
-                                        None
-                                    } else {
-                                        Some(CimeAuth { access_token: v })
-                                    };
-                                });
+                                secret_inputs.update(|s| s.cime_access_token = v);
                             } />
+                        <span id="cime-token-hint" class="hint">{move || cime_token_hint()}</span>
                     </div>
                 </fieldset>
 
                 <button type="submit">"저장 및 연결"</button>
-                <p role="status" aria-live="polite">{save_msg}</p>
+                <p role="status" aria-live="polite">{move || save_msg()}</p>
             </form>
         </section>
     }
 }
 
-fn set_chzzk_field(s: &mut Settings, mutate: impl FnOnce(&mut ChzzkAuth)) {
-    let entry = s.chzzk.get_or_insert_with(|| ChzzkAuth {
-        client_id: String::new(),
-        client_secret: String::new(),
+async fn apply_and_save(settings: Settings, secrets: SecretInputs) -> Result<(), IpcError> {
+    let chzzk_secret = (!secrets.chzzk_client_secret.trim().is_empty()).then_some(ChzzkSecrets {
+        client_secret: secrets.chzzk_client_secret,
         access_token: None,
     });
-    mutate(entry);
-    if entry.client_id.is_empty() && entry.client_secret.is_empty() && entry.access_token.is_none()
-    {
-        s.chzzk = None;
+    let cime_secret = (!secrets.cime_access_token.trim().is_empty()).then_some(CimeSecrets {
+        access_token: secrets.cime_access_token,
+    });
+
+    if chzzk_secret.is_some() || cime_secret.is_some() {
+        ipc::save_secrets(chzzk_secret, cime_secret).await?;
     }
-}
+    ipc::save_settings(settings.clone()).await?;
 
-async fn apply_and_save(payload: Settings) -> Result<(), IpcError> {
-    ipc::save_settings(payload.clone()).await?;
-
-    if payload.mock_enabled {
+    if settings.mock_enabled {
         let _ = ipc::start_mock_source().await;
     } else {
         let _ = ipc::stop_mock_source().await;
     }
 
-    if payload.chzzk.is_some() {
+    let presence = ipc::get_secrets_presence()
+        .await
+        .unwrap_or(SecretsPresence {
+            chzzk_present: false,
+            cime_present: false,
+        });
+
+    let chzzk_ready = settings
+        .chzzk_client_id
+        .as_deref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+        && presence.chzzk_present;
+    if chzzk_ready {
         let _ = ipc::start_event_source(Platform::Chzzk).await;
     } else {
         let _ = ipc::stop_event_source(Platform::Chzzk).await;
     }
 
-    if payload.cime.is_some() {
+    if presence.cime_present {
         let _ = ipc::start_event_source(Platform::Cime).await;
     } else {
         let _ = ipc::stop_event_source(Platform::Cime).await;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,6 +1,9 @@
 use leptos::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use shared::{EventEnvelope, IpcError, Platform, Settings, SummaryRequest, SummaryResponse};
+use shared::{
+    ChzzkSecrets, CimeSecrets, EventEnvelope, IpcError, Platform, SecretsPresence, Settings,
+    SummaryRequest, SummaryResponse,
+};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -59,6 +62,12 @@ struct SettingsArgs {
 }
 
 #[derive(Serialize)]
+struct SecretsArgs {
+    chzzk: Option<ChzzkSecrets>,
+    cime: Option<CimeSecrets>,
+}
+
+#[derive(Serialize)]
 struct SummarizeArgs {
     req: SummaryRequest,
 }
@@ -69,6 +78,17 @@ pub async fn get_settings() -> Result<Settings, IpcError> {
 
 pub async fn save_settings(settings: Settings) -> Result<(), IpcError> {
     invoke_unit("save_settings", SettingsArgs { settings }).await
+}
+
+pub async fn save_secrets(
+    chzzk: Option<ChzzkSecrets>,
+    cime: Option<CimeSecrets>,
+) -> Result<(), IpcError> {
+    invoke_unit("save_secrets", SecretsArgs { chzzk, cime }).await
+}
+
+pub async fn get_secrets_presence() -> Result<SecretsPresence, IpcError> {
+    invoke_typed("get_secrets_presence", Empty {}).await
 }
 
 pub async fn start_event_source(platform: Platform) -> Result<(), IpcError> {


### PR DESCRIPTION
Closes #1

## Summary

- `chzzk.client_secret` / `chzzk.access_token` / `cime.access_token`을 `tauri-plugin-store`의 평문 JSON에서 OS 자격증명 매니저(Win Credential Manager / macOS Keychain / Linux Secret Service)로 이주.
- `shared::Settings`를 비비밀 필드만 보유하도록 분해. 비밀은 별도 `ChzzkSecrets`/`CimeSecrets` 타입으로 분리해 컴파일 타임에 평문 직렬화 회귀를 차단.
- `get_settings` 내부 idempotent 마이그레이션으로 기존 사용자도 1회 자동 이주, 폼 UX는 그대로 유지.

## 라이브러리 결정 변경: stronghold → keyring

이슈 제목은 "Stronghold로 이주"였으나 조사 후 `keyring` 크레이트로 변경. 사유는 [issue 코멘트](https://github.com/GG-O-BP/jeomjwabot/issues/1#issuecomment-4332383161) 참조 — 모바일 호환 미확인, vault 비밀번호 UX 부담(시각장애인 1차 사용자), Tauri 커뮤니티의 deprecation 우려.

## 핵심 변경

### shared
- `Settings`: `chzzk: Option<ChzzkAuth>` / `cime: Option<CimeAuth>` 제거 → `chzzk_client_id: Option<String>` 추가 (비비밀만)
- 신규: `ChzzkSecrets { client_secret, access_token }`, `CimeSecrets { access_token }`, `SecretsPresence { chzzk_present, cime_present }`
- `ChzzkAuth` / `CimeAuth`는 WS/HTTP 호출의 런타임 합성 타입으로 유지

### 백엔드
- `src-tauri/src/secrets.rs` 신규 — keyring 래퍼. `SERVICE = "jeomjwabot"`, 키: `chzzk.client_secret` / `chzzk.access_token` / `cime.access_token`. `tauri::async_runtime::spawn_blocking`으로 감싼 async 헬퍼 제공.
- 신규 IPC: `save_secrets(Option<ChzzkSecrets>, Option<CimeSecrets>)`, `get_secrets_presence() -> SecretsPresence` (평문 절대 노출 X)
- `get_settings` 내부에서 구 형식(`chzzk.client_secret` 등) 발견 시 keyring으로 이주 후 store에서 비밀 키 제거. idempotent.
- `start_event_source`가 `Settings + Secrets`로 `ChzzkAuth` / `CimeAuth` 합성

### 프론트엔드
- 시크릿 입력 backing을 `Settings`에서 떼어내 폼 로컬 `secret_inputs: RwSignal<SecretInputs>`로. 컴파일 타임에 `Settings`로의 비밀 누출 차단.
- `LocalResource<SecretsPresence>`로 마운트 시 fetch → password input의 `aria-describedby` hint를 "저장 상태 확인 중." / "저장됨. 변경하려면 새 값 입력." / "아직 저장되지 않음."으로 분기
- `apply_and_save` 순서: `save_secrets` → `save_settings` → 연결 시작 (비밀이 keyring에 들어간 후 `start_event_source`가 keyring을 읽도록)
- `Effect`로 액션 완료 시 `presence.refetch()` 트리거 (외부 세계 캐시 동기화)
- 폼 DOM/label/fieldset/legend/`aria-live` 모두 그대로 — 사용자가 보는 UX는 변하지 않음

## 13대 원칙 / 접근성 정합

- #5 외부 동기화 전용 `Effect` ✓ (액션 완료 후 LocalResource refetch)
- #6 비동기 `Resource` 통합 ✓ (`LocalResource` 사용, raw `spawn_local` 추가 X)
- #7 shared 단일 정의 ✓
- #10 점자/스크린리더 1차 ✓ (로딩 상태 거짓 announce 방지, 점자 폭 단축: hint 24자→16자, interval-help 33자→22자)
- #12 타입 안전 IPC 래퍼 ✓ (`src/ipc.rs`에 `save_secrets`/`get_secrets_presence` 추가)
- `src-tauri/CLAUDE.md` "토큰은 OS keyring에 저장. plain text 파일/JSON에 저장 금지" 충족 ✓

## 검증 (자동)

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] leptos-reviewer 13대 원칙 감사 (위반 2건 수정 후 통과)
- [x] accessibility-auditor 점자·ARIA 감사 (위반 4건 수정 후 통과)

## Test plan (수동, 데스크톱 dev — 머지 전 확인 필요)

- [ ] **신규 설치**: `%APPDATA%\<appid>\settings.json` 삭제 + Windows 자격 증명 관리자에서 `jeomjwabot:*` 항목 삭제 → `cargo tauri dev` → 폼에 cid/secret/cime token 입력 → "저장 및 연결" → 종료 → `settings.json`에 `client_secret`/`access_token` 키 부재 확인 → 자격 증명 관리자에 `jeomjwabot:chzzk.client_secret` 등 항목 존재 확인 → 재시작 후 자동 연결 (트레이스 로그 `치지직 세션` 확인)
- [ ] **마이그레이션**: 직전 커밋(`git stash` 또는 `main` 체크아웃)으로 평문 `settings.json` 생성 → 본 PR 빌드로 재기동 → 폼 hydrate 직후 `settings.json`에서 비밀 키 사라지고 keyring으로 이주됐는지 확인
- [ ] **부분 입력**: chzzk만 채우고 cime는 비움 → 저장 → keyring에 `chzzk.*` 항목만, cime는 NoEntry → `start_event_source(Cime)`이 `MissingConfig`로 실패하는지 (UI 영향 없음)
- [ ] **WS 정합**: 위 시나리오에서 mock 끄고 실 토큰 사용 → `live-event` 수신 확인
- [ ] **점자/화면리더 hint**: NVDA 또는 한소네 + 화면리더로 폼 진입 시 password input의 hint가 "저장 상태 확인 중." → "저장됨. 변경하려면 새 값 입력." 로 자연스럽게 정정 announce되는지

## 후속 (별도 이슈)

- #5/#6 모바일 빌드 진입 시 `keyring-rs` Android 호환성 재평가, 필요 시 device-derived encrypted store fallback
- "저장된 비밀 명시 삭제" UI (현재는 입력 비움 ≠ 삭제). 이번 PR 범위 외

🤖 Generated with [Claude Code](https://claude.com/claude-code)